### PR TITLE
Swtich appsream validation tool to appstreamcli

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -25,10 +25,10 @@ appstream_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'appdata')
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util,
-    args: ['validate', appstream_file]
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('Validate appstream file', appstreamcli,
+    args: ['validate', '--no-net', appstream_file]
   )
 endif
 


### PR DESCRIPTION
appstream-glib is essentially not updated to follow any recent version of the specification so it will give some outdated issues nowadays.
`appstream` and it's validation tool follows the more closely. 
The `--no-net` flag helps to pass the appreamcli tests, and it is important for packaging for debian, as it is required for reproducible builds